### PR TITLE
Implements Objective C delegate support

### DIFF
--- a/examples/delegate.py
+++ b/examples/delegate.py
@@ -1,0 +1,44 @@
+"""
+This example simplifies the code from the URL Loading System Programming Guide
+(http://goo.gl/JJ2Q8T). It uses NSURLConnection to request an invalid connection
+and get the connection:didFailWithError: delegate method triggered.
+"""
+from kivy.app import App
+from kivy.uix.widget import Widget
+from pyobjus import autoclass, objc_delegate, objc_str
+from pyobjus.dylib_manager import load_framework, INCLUDE
+
+load_framework(INCLUDE.AppKit)
+load_framework(INCLUDE.Foundation)
+
+NSURL = autoclass('NSURL')
+NSURLConnection = autoclass('NSURLConnection')
+NSURLRequest = autoclass('NSURLRequest')
+
+
+class MyObjcDelegate:
+  """A delegate class implemented in Python."""
+
+  def connection_didFailWithError_(self, connection, error):
+    print("Protocol method got called!!", connection, error)
+
+
+def request_connection():
+    # This method request connection to an invalid URL so the
+    # connection_didFailWithError_ protocol method will be triggered.
+    url = NSURL.URLWithString_(objc_str('abc'))
+    request = NSURLRequest.requestWithURL_(url)
+    # Converts the Python delegate object to Objective C delegate instance
+    # simply by calling the objc_delegate() function.
+    delegate = objc_delegate(MyObjcDelegate(), ['NSURLConnectionDelegate'])
+    connection = NSURLConnection.connectionWithRequest_delegate_(request,
+                                                                 delegate)
+
+
+class DelegateApp(App):
+  def build(self):
+    request_connection()
+    return Widget()
+
+if __name__ == "__main__":
+    DelegateApp().run()

--- a/pyobjus/runtime.pxi
+++ b/pyobjus/runtime.pxi
@@ -1,9 +1,21 @@
+cdef extern from "stdarg.h":
+    ctypedef struct va_list:
+        pass
+    ctypedef struct fake_type:
+        pass
+    void va_start(va_list, void* arg)
+    void* va_arg(va_list, fake_type)
+    void va_end(va_list)
+    fake_type id_type "id"
+
 cdef extern from "objc/objc.h":
-    
+
     ctypedef enum: YES
     ctypedef enum: NO
 
 cdef extern from "objc/runtime.h":
+
+    ctypedef signed char BOOL
 
     ctypedef struct objc_selector:
         pass
@@ -13,6 +25,10 @@ cdef extern from "objc/runtime.h":
         pass
     ctypedef objc_ivar* Ivar
 
+    cdef struct objc_method_description:
+        SEL name
+        char* types
+
     ctypedef struct objc_property:
         pass
     ctypedef objc_property* objc_property_t
@@ -21,12 +37,18 @@ cdef extern from "objc/runtime.h":
     ctypedef void* id
     ctypedef void* Class
     ctypedef void* Method
+    ctypedef void* Protocol
 
+    ctypedef id(*IMP)(id, SEL, ...)
+
+    id              objc_allocateClassPair(Class superclass, const_char_ptr name, size_t extraBytes)
     id              objc_getClass(const_char_ptr name)
     id              objc_getRequiredClass(const_char_ptr)
-    id              objc_msgSend(id, objc_selector *, ...) 
+    id              objc_msgSend(id, objc_selector *, ...)
     void            objc_msgSend_stret(id self, SEL selector, ...)
+    void            objc_registerClassPair(Class cls)
 
+    BOOL            class_addMethod(Class cls, SEL name, IMP imp, const char *types)
     id              class_createInstance(Class cls, unsigned int)
     Method*         class_copyMethodList(Class cls, unsigned int *outCount)
     const_char_ptr  class_getName(Class cls)
@@ -36,17 +58,19 @@ cdef extern from "objc/runtime.h":
     Ivar*           class_copyIvarList(Class cls, unsigned int *outCount)
     objc_property_t* class_copyPropertyList(Class cls, unsigned int *outCount)
     Ivar            class_getInstanceVariable(Class cls, const_char_ptr name)
-    const_char_ptr  class_getName(Class cls)
+
+    Protocol*       objc_getProtocol(const_char_ptr name)
 
     const_char_ptr  ivar_getName(Ivar ivar)
     const_char_ptr  ivar_getTypeEncoding(Ivar ivar)
 
     SEL             sel_registerName(char *)
     const_char_ptr  sel_getName(SEL)
-    
+
     SEL             method_getName(Method)
     const_char_ptr  method_getTypeEncoding(Method)
     const_char_ptr  method_copyArgumentType(Method method, int)
+    objc_method_description* method_getDescription(Method m)
 
     Class           object_getClass(id obj)
     const_char_ptr  object_getClassName(id obj)
@@ -57,6 +81,7 @@ cdef extern from "objc/runtime.h":
 
     const_char_ptr  property_getAttributes(objc_property_t property)
     const_char_ptr  property_getName(objc_property_t property)
+    objc_method_description* protocol_copyMethodDescriptionList(Protocol *p, BOOL isRequiredMethod, BOOL isInstanceMethod, unsigned int *outCount)
 
 cdef extern from "_runtime.h":
     void  pyobjc_internal_init()


### PR DESCRIPTION
The delegate support is achieved by a objc_delegate() function that converts a Python object to the corresponded Objective C delegate instance. A list of protocols intended to conform are also passed to the objc_delegate() function.

The objc_delegate() dynamically creates a new Objective C class inherited by NSObject, then adds desired protocols methods and instantiates the instance. The instance is converted to Python object before returned so it can be passed to other MetaObjcClass methods that requires delegate instance.

In order to achieve dynamic implementation of protocol methods. A `delegate_register` dict is added to remember the class name and corresponded Python object. So the dynamic function can dispatch the call to real Python object's method. However, currently registered delegates won't get released. Still looking for a way to free unused objects.

This commit also adds an example at exampls/delegate.py. However, because the protocol method will be called asynchronously. I needs to write the example as a simple Kivy app so the execution won't quit before the protocol instance gets called. There may be a simpler way to implement a event loop but I failed.

There is another problem about dynamically creating an Objective C class. That is, we need to use the objc_getProtocol() runtime function to find interested protocol methods (for signature and types). However, it seems not all protocols can be found through this function. More information about this issue can be found here: http://goo.gl/zA116F

Signed-off-by: Olli Wang olliwang@ollix.com
