### PR TITLE
fix ARM64 delegate

### DIFF
--- a/pyobjus/pyobjus_conversions.pxi
+++ b/pyobjus/pyobjus_conversions.pxi
@@ -680,13 +680,16 @@ cdef void* convert_py_arg_to_cy(arg, sig, by_value, size_t size) except *:
             # ARRAY, ETC.
         else:
             # TODO: Add better conversion between primitive types!
-            if type(arg) is float:
-                (<float*>arg_val_ptr)[0] = <float>arg
-            elif type(arg) is int:
-                (<int*>arg_val_ptr)[0] = <int>arg
-            elif type(arg) is str:
-                strcpy(<char*>arg_val_ptr, <char*>arg)
-            (<void**>val_ptr)[0] = <void*>arg_val_ptr
+            if type(arg) is long:
+                (<void**>val_ptr)[0] = <void*><unsigned long long>arg
+            else:
+                if type(arg) is float:
+                    (<float*>arg_val_ptr)[0] = <float>arg
+                elif type(arg) is int:
+                    (<int*>arg_val_ptr)[0] = <int>arg
+                elif type(arg) is str:
+                    strcpy(<char*>arg_val_ptr, <char*>arg)
+                (<void**>val_ptr)[0] = <void*>arg_val_ptr
         
     # TODO: method is accepting bit field
     elif sig[0] == 'b':

--- a/pyobjus/runtime.pxi
+++ b/pyobjus/runtime.pxi
@@ -44,7 +44,7 @@ cdef extern from "objc/runtime.h":
     id              objc_allocateClassPair(Class superclass, const_char_ptr name, size_t extraBytes)
     id              objc_getClass(const_char_ptr name)
     id              objc_getRequiredClass(const_char_ptr)
-    id              objc_msgSend(id, objc_selector *, ...)
+    id              objc_msgSend(id, SEL, ...)
     void            objc_msgSend_stret(id self, SEL selector, ...)
     void            objc_registerClassPair(Class cls)
 


### PR DESCRIPTION
Since ARM64 introduction (iOS 8), delegate implementation are using the "slow" path of objective-c.
We are not able anymore to declare a variadic function for responding to any kind of selector, as the ARM64 convention call differ from other platform, and va_start/arg/end doesn't work on ARM64 as well.

Instead, we are manually using forwardInvocation:, named as the "slow" path.
Ref: http://arigrant.com/blog/2013/12/13/a-selector-left-unhandled

The idea is, when there is no implementation of a selector on the target, objc will forward the call to a forwardInvocation: selector on the target, containing the original invocation and parameters in a NSInvocation. For pyobjus, it's separated in 3 steps:

- respondsToSelector: > the target class must indicate which selector is implemented in Python
- methodSignatureForSelector: > the target class must return a NSMethodSignature for the selector
- forwardInvocation: > and then, the message will be passed to it