### PR TITLE
fix passing bytes as void*

### DIFF
--- a/pyobjus/pyobjus_conversions.pxi
+++ b/pyobjus/pyobjus_conversions.pxi
@@ -682,13 +682,14 @@ cdef void* convert_py_arg_to_cy(arg, sig, by_value, size_t size) except *:
             # TODO: Add better conversion between primitive types!
             if type(arg) is long:
                 (<void**>val_ptr)[0] = <void*><unsigned long long>arg
+            elif type(arg) is str:
+                # passing bytes as void* is the same as for char*
+                (<char **>val_ptr)[0] = <char *><bytes>arg
             else:
                 if type(arg) is float:
                     (<float*>arg_val_ptr)[0] = <float>arg
                 elif type(arg) is int:
                     (<int*>arg_val_ptr)[0] = <int>arg
-                elif type(arg) is str:
-                    strcpy(<char*>arg_val_ptr, <char*>arg)
                 (<void**>val_ptr)[0] = <void*>arg_val_ptr
         
     # TODO: method is accepting bit field


### PR DESCRIPTION
Pass bytes to `void*` the same as we do to `char*`. This fixes an issue with calling `NSData.dataWithBytes_length_(bytestr, len(bytestr))` and ending up with a data object which doesn't contain the correct data.

Technically, the arg type is `^v` and the `^` has already been stripped off, so the type passed to `convert_py_arg_to_cy` is just `v` - void rather than a void pointer. However, you can never pass a void, only a void pointer, so it's safe to assume that the original arg type was `^v`. 
