### PR TITLE
Update documentation

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -121,7 +121,7 @@ Utility functions
 
     Initialize `NSNumber` with a `NSString` type.
 
-    :param some_float: String parameter
+    :param some_string: String parameter
     :rtype: NSString.stringWithUTF8String: Python representation
 
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -179,7 +179,7 @@ Pyobjus Objective C types
 
 .. class:: ObjcLong
 
-    Objective C ``long`` representation 
+    Objective C ``long`` representation
 
 .. class:: ObjcLongLong
 
@@ -257,7 +257,7 @@ Pyobjus Objective C types
 
     Representation of some Objective C exception
 
-    
+
 .. module:: pyobjus.objc_py_types
 
 Structure types

--- a/docs/source/core_tutorials.rst
+++ b/docs/source/core_tutorials.rst
@@ -12,7 +12,7 @@ You need to load code into pyobjus so it can actually find the appropriate
 class with the autoclass function.
 
 Maybe you want to write some Objective C code, and you want to load it into
-pyobjus, or you want to use some exising `.dylib` or sommething similar. 
+pyobjus, or you want to use some exising `.dylib` or sommething similar.
 
 These problems can be solved using the pyobjus dylib_manager. Currently it has
 a few functions, so let's see what we can do with them.
@@ -397,25 +397,25 @@ pyobjus will convert the value to that type.
 
 Here is the list of possible types::
 
-    'ObjcChar', 
-    'ObjcInt', 
-    'ObjcShort', 
-    'ObjcLong', 
-    'ObjcLongLong', 
-    'ObjcUChar', 
-    'ObjcUInt', 
-    'ObjcUShort', 
-    'ObjcULong', 
-    'ObjcULongLong', 
-    'ObjcFloat', 
-    'ObjcDouble', 
-    'ObjcBool', 
-    'ObjcBOOL', 
-    'ObjcVoid', 
-    'ObjcString', 
-    'ObjcClassInstance', 
-    'ObjcClass', 
-    'ObjcSelector', 
+    'ObjcChar',
+    'ObjcInt',
+    'ObjcShort',
+    'ObjcLong',
+    'ObjcLongLong',
+    'ObjcUChar',
+    'ObjcUInt',
+    'ObjcUShort',
+    'ObjcULong',
+    'ObjcULongLong',
+    'ObjcFloat',
+    'ObjcDouble',
+    'ObjcBool',
+    'ObjcBOOL',
+    'ObjcVoid',
+    'ObjcString',
+    'ObjcClassInstance',
+    'ObjcClass',
+    'ObjcSelector',
     'ObjcMethod'
 
 Those already listed types are defined inside the pyobjus module, so you can

--- a/docs/source/core_tutorials.rst
+++ b/docs/source/core_tutorials.rst
@@ -478,6 +478,9 @@ Objective C equivalents are::
     # NSNumber *noNumber = @NO;             // equivalent to [NSNumber numberWithBool:NO]
     objc_b(False)
 
+    # NSString *string = @"some string";
+    objc_str('some string')
+
     # NSArray *array = @[ @"Hello", NSApp, [NSNumber numberWithInt:42] ];
     objc_arr(objc_str('Hello'), objc_str('some str'), objc_i(42))
 
@@ -491,9 +494,6 @@ Objective C equivalents are::
         'date': autoclass('NSDate').date(),
         'processInfo': autoclass('NSProcessInfo').processInfo()
     })
-
-    # NSString *string = @"some string";
-    objc_str('some string')
 
 We have tried to make the build names for these literals clear and intuitive.
 We start with the prefix ``objc_`` followed by the letter/letters which denote

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -53,14 +53,14 @@ Then we can use the NSAlert object::
 
     from pyobjus import autoclass
 
+    # mimic the constant string operator (@"hello") in objective C
+    from pyobjus import objc_str
+
     # get both nsalert and nsstring class
     NSAlert = autoclass('NSAlert')
     NSString = autoclass('NSString')
-     
-    # shortcut to mimic the @"hello" in objective C
-    ns = lambda x: NSString.alloc().initWithUTF8String_(x)
-     
+
     # create an NSAlert object, and show it.
     alert = NSAlert.alloc().init()
-    alert.setMessageText_(ns('Hello world!'))
+    alert.setMessageText_(objc_str('Hello world!'))
     alert.runModal()


### PR DESCRIPTION
Some minor pyobjus docs fixes.

* Fix a (presumed) data type-typo in the docs, 
* rearrange an example to introduce `objc_str`  using it for something else, 
* Use the in-built `objc_str` import instead of redoing it as a lambda

While here, fix some whitespace issues.