### PR TITLE
Fix delegate instance

### DIFF
--- a/pyobjus/pyobjus.pyx
+++ b/pyobjus/pyobjus.pyx
@@ -954,6 +954,8 @@ cdef ObjcClassInstance objc_create_delegate(py_obj):
     cdef dict delegates = {}
     cdef int protocol_found = 0
 
+    if objc_cls == <Class>0x0:
+        raise MemoryError("Class allocation failed for {}".format(cls_name))
     dprint('create delegate from {!r}'.format(py_obj))
 
     # XXX this was the code for older delegate creatieon

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -101,3 +101,14 @@ class DelegateTest(unittest.TestCase):
         # if everything is find, the keyboard should instanciate
         # without issue
         iOSKeyboard = IOSKeyboard()
+
+    def test_multiple_delegates(self):
+      # Ensure we can create delegates for multiple instances of the same class
+      # PR #50: https://github.com/kivy/pyobjus/pull/50
+      conn1 = DelegateExample()
+      conn2 = DelegateExample()
+      conn1.request_connection()
+      conn2.request_connection()
+      cf.CFRunLoopRunInMode(K_CF_RUNLOOP_DEFAULT_MODE, 1, False)
+      self.assertTrue(conn1.delegate_called)
+      self.assertTrue(conn2.delegate_called)


### PR DESCRIPTION
## Overview
Pyobjus has the ability to specify a python class as a delegate for an Objective C call by using the `@prototol` decorator.

However, this will crash on a MacOS or IOS target if the delegate is referenced a second time (say by instantiating an Widget that wraps an Objective C method in two different places)

## Diagnosis
The bug occurs when `convert_py_to_nsobject` invokes
https://github.com/kivy/pyobjus/blob/f84a58e9b301bffad508e13ccade6c0cdf79e2a3/pyobjus/pyobjus_conversions.pxi#L452

This dynamically creates an Objective C class here:
https://github.com/kivy/pyobjus/blob/f84a58e9b301bffad508e13ccade6c0cdf79e2a3/pyobjus/pyobjus.pyx#L933-L934

Unfortunately, this call fails (and returns `nil`) when called a second time with the same c_cls_name.
Rrom the docs: 
> Return Value: The new class, or `Nil` if the class could not be created (for example, **the desired name is already in use**)

There's never any check for this `nil`, and so we eventually crash here:
https://github.com/kivy/pyobjus/blob/f84a58e9b301bffad508e13ccade6c0cdf79e2a3/pyobjus/pyobjus.pyx#L992

Note, there is a cache that prevents this from happening from the same python object, but here we have two separate objects, so the cache check misses:
https://github.com/kivy/pyobjus/blob/f84a58e9b301bffad508e13ccade6c0cdf79e2a3/pyobjus/pyobjus.pyx#L924-L927

## Reproducer
Here we create a `URLButton` that invokes an `NSURLRequest` to a garbage URL when pressed. We specify the error handler (ourselves) with the a `NSURLConnectionDelegate` protocol handler.

Pressing either of the buttons works as expected, but if you press the second button, the app will crash. 

```
"""
Demonstrate a bug where a second delegate with the same object name
will crash on an IOS device
"""
import kivy
from kivy.app import App
from kivy.lang import Builder
from kivy.properties import StringProperty
from kivy.uix.button import Button
from pyobjus import autoclass, protocol, objc_str
from pyobjus.dylib_manager import load_framework, INCLUDE

load_framework(INCLUDE.Foundation)

NSURL = autoclass('NSURL')
NSURLConnection = autoclass('NSURLConnection')
NSURLRequest = autoclass('NSURLRequest')

class URLButton(Button):
    url = StringProperty(None)
    def request_connection(self):
        # This method request connection to an invalid URL so the
        # connection_didFailWithError_ protocol method will be triggered.
        url = NSURL.URLWithString_(objc_str(self.url))
        request = NSURLRequest.requestWithURL_(url)
        # Converts the Python delegate object to Objective C delegate instance
        # simply by calling the objc_delegate() function.
        connection = NSURLConnection.connectionWithRequest_delegate_(
                request, self)

        return connection

    @protocol('NSURLConnectionDelegate')
    def connection_didFailWithError_(self, connection, error):
        self.text = "NSURLConnectionDelegate:\nconn:{}\nerr:{}".format(connection,
                                                                       error)

kv = Builder.load_string("""
#:kivy 1.10.1

BoxLayout:
    orientation: 'vertical'
    URLButton:
        url: 'foo'
    URLButton:
        url: 'bar'
<URLButton>:
    url: 'abc'
    text: 'fetch {}'.format(self.url)
    on_release: self.request_connection()
    text_size: self.size
""")

class DelegateBugApp(App):
    def build(self):
        self.root = kv
        return self.root


if __name__ == "__main__":
    DelegateBugApp().run()
```

## Fix

When creating a delegate, Instead of creating a wrapper class based solely on the class name
of the python class, base it on the instance of the python class.

Create a custom "repr" style name (incorporating module, classname, id()) in case the Class has overloaded its `repr()`. This involves some gymnastics, as the `id` builtin is overridden to handle the objective-c `id` builtin.

Fixes #49 

## Caveats
* I've only tested this on python 2 so far.

* It's possible this could create a lot of extra classes lying about, and we should maybe be more clever about recycling or garbage collecting them, but clearly, pyobjus isn't being used in such a context right now (as such an application would crash on the second such use)

* in theory, `id()` is only good up to the lifetime of the python object, so it's possible (though highly unlikely) that it could get reused. There should probably be a `__del__` method on the python caller to remove itself from the object cache, and an associated method to handle that behavior. (This could be a separate PR, as it requires new functionality and a documentation change.)

