### PR TITLE
Fixes universal2 build

### DIFF
--- a/pyobjus/_runtime.h
+++ b/pyobjus/_runtime.h
@@ -40,3 +40,16 @@ void drainAutoreleasePool(id pool) {
 id objc_msgSend_custom(id obj, SEL sel){
   return ((id (*)(id, SEL)) objc_msgSend)(obj, sel); 
 }
+
+#if TARGET_OS_OSX && TARGET_CPU_X86_64
+  void objc_msgSend_stret__safe(id _Nullable self, SEL _Nonnull op){
+      ((id (*)(id, SEL)) objc_msgSend_stret)(self, op);
+  }
+
+  bool MACOS_HAVE_OBJMSGSEND_STRET = true;
+#else
+  void objc_msgSend_stret__safe(id _Nullable self, SEL _Nonnull op){
+  }
+
+  bool MACOS_HAVE_OBJMSGSEND_STRET = false;
+#endif

--- a/pyobjus/common.pxi
+++ b/pyobjus/common.pxi
@@ -159,3 +159,5 @@ cdef extern from "_runtime.h":
     id    allocAndInitAutoreleasePool()
     void  drainAutoreleasePool(id pool)
     id    objc_msgSend_custom(id obj, SEL sel)
+    void  objc_msgSend_stret__safe(id self, SEL selector, ...)
+    bool  MACOS_HAVE_OBJMSGSEND_STRET

--- a/pyobjus/pyobjus.pyx
+++ b/pyobjus/pyobjus.pyx
@@ -448,8 +448,8 @@ cdef class ObjcMethod(object):
                 if self.signature_return[0].startswith((b'{', b'(')) and size_ret > 16:
                     stret = True
 
-                if ARCH!= 'arm64' and stret:
-                    ffi_call(&self.f_cif, <void(*)()><id(*)(id, SEL)>objc_msgSend_stret, res_ptr, f_args)
+                if stret and MACOS_HAVE_OBJMSGSEND_STRET:
+                    ffi_call(&self.f_cif, <void(*)()><id(*)(id, SEL)>objc_msgSend_stret__safe, res_ptr, f_args)
                     fun_name = "objc_msgSend_stret"
                     del_res_ptr = False
                 else:


### PR DESCRIPTION
The previous `ARCH!= 'arm64'` implementation for checking if we were building for `arm64` worked great until **python3.10**, which by default builds a  `universal2` wheel that contains binaries for both `x86_64` and `arm64` also on `x86_64` macs.

WARNING: I didn't have the chance to test on runtime if a call to `objc_msgSend_stret` works fine, and the tests probably need to be improved and have to run on CI.

Fixes issue #81 