### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/source/core_tutorials.rst
+++ b/docs/source/core_tutorials.rst
@@ -12,7 +12,7 @@ You need to load code into pyobjus so it can actually find the appropriate
 class with the autoclass function.
 
 Maybe you want to write some Objective C code, and you want to load it into
-pyobjus, or you want to use some exising `.dylib` or sommething similar.
+pyobjus, or you want to use some exising `.dylib` or something similar.
 
 These problems can be solved using the pyobjus dylib_manager. Currently it has
 a few functions, so let's see what we can do with them.

--- a/docs/source/pyobjus_ios.rst
+++ b/docs/source/pyobjus_ios.rst
@@ -124,7 +124,7 @@ You can open this project with xcode as follows::
 If you have setup your developer account, you only need to click play and the
 app will be deployed on your iOS device.
 
-This is screenshoot from my iPad.
+This is screenshot from my iPad.
 
 .. figure::  images/IMG_0322.PNG
    :align:   center
@@ -453,7 +453,7 @@ After this step, xcode will open and, if you have connected your iOS
 device to your computer, you can run the project and will see your app
 running on your device.
 
-This is a screenshoot from an iPad.
+This is a screenshot from an iPad.
 
 .. figure::  images/IMG_0330.PNG
    :align:   center

--- a/examples/pointer_to_type.py
+++ b/examples/pointer_to_type.py
@@ -39,14 +39,14 @@ sel_ptr = car.makeSelectorPtr()
 car.useSelectorPtr_(sel_ptr)
 
 # but what if we have selector value (not reference) and we want to call method which accepts reference, not value?
-# Luckily pyobjus is smart enought to figure out that method which we call accepts reference, 
+# Luckily pyobjus is smart enough to figure out that method which we call accepts reference, 
 # and also knows are we passing reference or value to some method.
 # So if we pass a value, he will by himself convert it to reference to some type which method accepts, 
 # and with this user is freed of thinking is method accepting value, or reference to some type
 car.useSelectorPtr_(sel)
 
 # As we knows, in native Objective C we can dereference pointer to get actual value on which pointer points
-# Pyobjus also have mechanism of dereferencing some pointer. He is also smart enought to know on which type 
+# Pyobjus also have mechanism of dereferencing some pointer. He is also smart enough to know on which type 
 # he need to cast value on which pointer points.
 sel = dereference(sel_ptr)
 print sel

--- a/examples/unions.py
+++ b/examples/unions.py
@@ -30,7 +30,7 @@ car = Car.alloc().init()
 union = car.makeUnion()
 print union.rect.origin.x, union.rect.origin.y
 
-# Also there is ability to call function which returns pointer to some unoin type
+# Also there is ability to call function which returns pointer to some union type
 # - (test_un_*) makeUnionPtr {
 #   test_un_ *un = malloc(sizeof(test_un_));
 #   NSRect rect = NSMakeRect(10, 30, 50, 60);
@@ -56,6 +56,6 @@ print union_val.rect.origin.x, union_val.rect.origin.y
 # }
 car.useUnionPtr_(union_ptr)
 
-# Because pyobjus internaly convert union values to union pointer (if that is needed),
-# we can also call this function by passing union value (value will be converted to pointer internaly)
+# Because pyobjus internally convert union values to union pointer (if that is needed),
+# we can also call this function by passing union value (value will be converted to pointer internally)
 car.useUnionPtr_(union)

--- a/examples/unknown_type.py
+++ b/examples/unknown_type.py
@@ -64,7 +64,7 @@ print ret_type.getMembers(only_types=True)
 # Pyobjus is using ctypes structures, so we can get actual pointer to c structure from python object,
 # but if we want to get working correct values of passed arg, we need to cast pointer to appropriate type
 # If type is defined in pyobjus/objc_cy_types pyobjus will cost it for us, but if it isn't, we will need to convert
-# it by ourselfs, for example internaly in function where we are passing struct value. Lets see example of this:
+# it by ourselfs, for example internally in function where we are passing struct value. Lets see example of this:
 
 # - (void) useUnknownStr:(void*)str_vp {
 #   unknown_str *str_p = (unknown_str*)str_vp;
@@ -78,7 +78,7 @@ car.useUnknownStr_(ret_type)
 
 # Another use-case of unknown type signature is with pointers to implementations of methods. 
 # As you known every method has pointer to IMP type, which is actual implementation of that method.
-# So, if we need to get IMP of some method, we can do sommething like this:
+# So, if we need to get IMP of some method, we can do something like this:
 imp = car.methodForSelector_(selector('getSumOf:and:'))
 
 # Method signature for return type of this function is ^?, so that is also some unknown type.


### PR DESCRIPTION
There are small typos in:
- docs/source/core_tutorials.rst
- docs/source/pyobjus_ios.rst
- examples/pointer_to_type.py
- examples/unions.py
- examples/unknown_type.py

Fixes:
- Should read `something` rather than `sommething`.
- Should read `screenshot` rather than `screenshoot`.
- Should read `internally` rather than `internaly`.
- Should read `enough` rather than `enought`.
- Should read `union` rather than `unoin`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md