### PR TITLE
Fix github release token

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,12 +39,11 @@ jobs:
 
     - name: Upload to GitHub Releases
       if: startsWith(github.ref, 'refs/tags/')
-      uses: softprops/action-gh-release@v0.1.5
+      uses: softprops/action-gh-release@v0.1.14
       env:
-        GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         files: dist/*
-        draft: false
 
     - name: Publish to PyPI
       if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
Drops old token which doesn't work and we don't need anymore.