### PR TITLE
Our self-hosted Apple Silicon runner now has been migrated to actions/runner v2.292.0 which now supports arm64 natively

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -6,10 +6,7 @@ jobs:
   build:
 
     name: "build (${{ matrix.runs_on }}, ${{ matrix.python }})"
-    defaults:
-      run:
-        shell: ${{ matrix.run_wrapper || 'bash --noprofile --norc -eo pipefail {0}' }}
-    runs-on: ${{ matrix.runs_on || 'macos-latest' }}
+    runs-on: ${{ matrix.runs_on }}
     strategy:
       matrix:
         include:
@@ -22,10 +19,8 @@ jobs:
           - runs_on: macos-latest
             python: "3.10"
           - runs_on: apple-silicon-m1
-            run_wrapper: arch -arm64 bash --noprofile --norc -eo pipefail {0}
             python: "3.9.11"
           - runs_on: apple-silicon-m1
-            run_wrapper: arch -arm64 bash --noprofile --norc -eo pipefail {0}
             python: "3.10.3"
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
- Same of https://github.com/kivy/kivy/pull/7885

- https://github.com/actions/runner/releases/tag/v2.292.0 now supports Apple Silicon natively. 🥳

- The run_wrapper that was enforcing arm64 on top of a x86_64 process is now un-needed.

- There's a pending PR in actions/python-versions which is expected to introduce support for universal2 versions of Python, so hopefully, we will be able to rely on actions/setup-python also for our self hosted runner in a while..