### PR TITLE
Add Python 3.11 to test matrix and update supported python versions list

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,10 +18,14 @@ jobs:
             python: "3.9"
           - runs_on: macos-latest
             python: "3.10"
+          - runs_on: macos-latest
+            python: "3.11"
           - runs_on: apple-silicon-m1
-            python: "3.9.11"
+            python: "3.9"
           - runs_on: apple-silicon-m1
-            python: "3.10.3"
+            python: "3.10"
+          - runs_on: apple-silicon-m1
+            python: "3.11"
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python }}

--- a/setup.py
+++ b/setup.py
@@ -134,10 +134,11 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
         'Operating System :: MacOS',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Topic :: Software Development :: Libraries :: Application Frameworks'
     ],
 )


### PR DESCRIPTION
- Updates the supported Python version list to be consistent with other Kivy projects (3.7-3.11)
- Add Python 3.11 to the test matrix