### PR TITLE
Add Discord and remove IRC from support channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,9 @@ If you need assistance, you can ask for help on our mailing list:
 * User Group : https://groups.google.com/group/kivy-users
 * Email      : kivy-users@googlegroups.com
 
-We also have an IRC channel:
+We also have a Discord server:
 
-* Server  : irc.freenode.net
-* Port    : 6667, 6697 (SSL only)
-* Channel : #kivy
+[https://chat.kivy.org/](https://chat.kivy.org/)
 
 
 ## Contributing


### PR DESCRIPTION
Update the support info to be consistent with other Kivy projects.