### PR TITLE
Add support for Python 3.12 (tests, wheel, docs)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: macos-latest
     env:
       CIBW_BUILD_VERBOSITY: 3
-      CIBW_BUILD: "cp37-macosx_x86_64 cp38-macosx_universal2 cp39-macosx_universal2 cp310-macosx_universal2 cp311-macosx_universal2"
+      CIBW_BUILD: "cp37-macosx_x86_64 cp38-macosx_universal2 cp39-macosx_universal2 cp310-macosx_universal2 cp311-macosx_universal2 cp312-macosx_universal2"
       CIBW_ARCHS_MACOS: "x86_64 universal2"
       CIBW_TEST_COMMAND: python -c "from pyobjus import autoclass, objc_str"
       CIBW_TEST_SKIP: "*arm64*"
@@ -21,7 +21,7 @@ jobs:
         python-version: '3.x'
 
     - name: Install dependencies
-      run: python -m pip install --upgrade twine cibuildwheel cython
+      run: python -m pip install --upgrade twine cibuildwheel~=2.16.2 cython
 
     - name: Build sdist
       run: |

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,6 +18,7 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
+          - "3.12"
         cython:
           - "<3"
           - ">=3"
@@ -41,7 +42,7 @@ jobs:
 
     - name: Install project
       run: |
-        pip install cython pytest
+        pip install cython pytest setuptools
         pip install .
 
     - name: Test with pytest

--- a/setup.py
+++ b/setup.py
@@ -142,6 +142,7 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Topic :: Software Development :: Libraries :: Application Frameworks'
     ],
 )


### PR DESCRIPTION
- Adds tests on Python 3.12
- Force `cibuildwheel` to `~=2.16.2`, so it can build `3.12` artifacts and add `cp312-macosx_universal2` to `CIBW_BUILD`
- Update docs