### PR TITLE
Remove support for Python `3.7` as reached EOL

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -13,7 +13,6 @@ jobs:
           - macos-latest
           - apple-silicon-m1
         python:
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"
@@ -23,8 +22,6 @@ jobs:
           - "<3"
           - ">=3"
         exclude:
-          - runs_on: apple-silicon-m1
-            python: "3.7"
           - runs_on: apple-silicon-m1
             python: "3.8"
           - runs_on: apple-silicon-m1

--- a/setup.py
+++ b/setup.py
@@ -140,7 +140,6 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
         'Operating System :: MacOS',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',


### PR DESCRIPTION
Removing Python `3.7` as reached EOL on June 27th 2023