### PR TITLE
Disable `-Wincompatible-function-pointer-types` in `testlib`

### DIFF
--- a/objc_classes/test/testlib.m
+++ b/objc_classes/test/testlib.m
@@ -159,7 +159,10 @@ typedef union test_un_ {
 }
 
 - (int) getandUseImpWithDefaultValues {
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wincompatible-function-pointer-types"
     return (int)[self useImp: [self getImp] withA: 7 andB: 5];
+    #pragma clang diagnostic pop
 }
 
 /******************** </UNKNOWN TYPE TESTS> ***********************/


### PR DESCRIPTION
Recent Xcode versions started to treat `Wincompatible-function-pointer-types` as an error.
Our test code for variadic functions actually takes advantage of this "feature".

This PR disables `-Wincompatible-function-pointer-types` checks on that chunk of code.


Maybe we should rewrite that test code to avoid that in future?