### PR TITLE
Fix KeyError(b'd') in make_type for unregistered struct types on Python 3

### DIFF
--- a/pyobjus/objc_py_types.py
+++ b/pyobjus/objc_py_types.py
@@ -141,9 +141,9 @@ class Factory(object):
             else:
                 if not field_name:
                     field_name, letter, perm_n, perms = self._generate_variable_name(letter, perm_n, perms)
-                    field_list.append((field_name, types[_type]))
-                else:
-                    field_list.append((field_name, types[_type]))
+                # The Cython layer passes bytes on Python 3; decode before lookup in the str-keyed dict.
+                _key = _type.decode("ascii") if isinstance(_type, bytes) else _type
+                field_list.append((field_name, types[_key]))
             self.field_name_ind += 1
         UnknownType._fields_ = field_list
         return UnknownType

--- a/tests/test_delegate.py
+++ b/tests/test_delegate.py
@@ -109,6 +109,11 @@ class DelegateTest(unittest.TestCase):
       conn2 = DelegateExample()
       conn1.request_connection()
       conn2.request_connection()
-      cf.CFRunLoopRunInMode(K_CF_RUNLOOP_DEFAULT_MODE, 1, False)
+      # Each connection_didFailWithError_ callback calls CFRunLoopStop, so the
+      # loop exits after the first failure.  Restart it until both have fired.
+      for _ in range(20):
+          cf.CFRunLoopRunInMode(K_CF_RUNLOOP_DEFAULT_MODE, 0.5, False)
+          if conn1.delegate_called and conn2.delegate_called:
+              break
       self.assertTrue(conn1.delegate_called)
       self.assertTrue(conn2.delegate_called)

--- a/tests/test_make_type_bytes.py
+++ b/tests/test_make_type_bytes.py
@@ -1,0 +1,84 @@
+"""
+Regression tests for the bytes/str mismatch in Factory.make_type.
+
+On Python 3, signature_types_to_list returns bytes items (e.g. b'd'), but the
+`types` dict in objc_py_types has str keys ('d').  Pre-registered structs
+(CGRect, NSRange, …) never hit make_type, so this was invisible until a
+non-pre-registered struct such as UIEdgeInsets was used.
+
+See: https://github.com/kivy/pyobjus/issues/148
+"""
+import ctypes
+import sys
+import unittest
+
+import pytest
+
+
+@pytest.mark.skipif(sys.platform != "darwin", reason="Only for macOS")
+class TestMakeTypeBytesDecode(unittest.TestCase):
+
+    def setUp(self):
+        from pyobjus.objc_py_types import Factory
+        self.factory = Factory()
+
+    # --- auto-generated field names (exercises line that was KeyError) -------
+
+    def test_double_fields_bytes_encoding(self):
+        """4-double struct (UIEdgeInsets shape) must not raise KeyError(b'd')."""
+        result = self.factory.make_type([b'TestEdgeInsets', b'dddd'])
+        self.assertTrue(issubclass(result, ctypes.Structure))
+        field_types = [ft for _, ft in result._fields_]
+        self.assertEqual(field_types, [ctypes.c_double] * 4)
+
+    def test_float_fields_bytes_encoding(self):
+        """2-float struct must not raise KeyError(b'f')."""
+        result = self.factory.make_type([b'TestFloatPair', b'ff'])
+        self.assertTrue(issubclass(result, ctypes.Structure))
+        field_types = [ft for _, ft in result._fields_]
+        self.assertEqual(field_types, [ctypes.c_float] * 2)
+
+    def test_mixed_primitive_fields_bytes_encoding(self):
+        """int + float struct exercises multiple type-dict lookups with bytes."""
+        result = self.factory.make_type([b'TestIntFloat', b'if'])
+        self.assertTrue(issubclass(result, ctypes.Structure))
+        field_types = [ft for _, ft in result._fields_]
+        self.assertEqual(field_types, [ctypes.c_int, ctypes.c_float])
+
+    def test_all_primitive_types_bytes_encoding(self):
+        """Every entry in the types dict must be reachable with a bytes key."""
+        from pyobjus.objc_py_types import types as type_map
+        for char, expected_ctype in type_map.items():
+            with self.subTest(type_char=char):
+                enc = char.encode("ascii")
+                result = self.factory.make_type([b'TestSingle_' + enc, enc])
+                self.assertTrue(issubclass(result, ctypes.Structure))
+                field_types = [ft for _, ft in result._fields_]
+                self.assertEqual(field_types, [expected_ctype])
+
+    # --- explicit member names (exercises the else branch with field_name set) -
+
+    def test_named_double_fields_bytes_encoding(self):
+        """Explicit member names must work with bytes type encoding."""
+        result = self.factory.make_type(
+            [b'TestEdgeInsetsNamed', b'dddd'],
+            members=['top', 'left', 'bottom', 'right'],
+        )
+        self.assertTrue(issubclass(result, ctypes.Structure))
+        self.assertEqual(
+            [(fn, ft) for fn, ft in result._fields_],
+            [('top', ctypes.c_double), ('left', ctypes.c_double),
+             ('bottom', ctypes.c_double), ('right', ctypes.c_double)],
+        )
+
+    def test_named_mixed_fields_bytes_encoding(self):
+        """Named int + float fields with bytes encoding."""
+        result = self.factory.make_type(
+            [b'TestPoint2D', b'ff'],
+            members=['x', 'y'],
+        )
+        self.assertTrue(issubclass(result, ctypes.Structure))
+        self.assertEqual(
+            [(fn, ft) for fn, ft in result._fields_],
+            [('x', ctypes.c_float), ('y', ctypes.c_float)],
+        )


### PR DESCRIPTION
## Summary

Fixes #148.

On Python 3, `signature_types_to_list` returns bytes items (e.g. `b'd'`), but the `types` dict in `objc_py_types.py` has str keys (`'d'`). Pre-registered structs (CGRect, NSRange, CGPoint, CGSize) are returned from the registry before `make_type` is ever called, which masked this bug. Any unregistered struct with primitive fields — including `UIEdgeInsets` — falls through to `make_type` and raises `KeyError: b'd'`.

## Changes

- **`pyobjus/objc_py_types.py`** — decode `_type` from bytes before the `types` dict lookup in `make_type`. Also collapsed the duplicated `field_list.append` that existed in both branches of `if not field_name` into a single statement.
- **`tests/test_make_type_bytes.py`** — new regression test file with 6 tests (+ 14 subtests) covering: 4-double struct (the UIEdgeInsets shape), float, mixed int/float, every primitive type in the dict via subtests, and both code paths (auto-generated field names and explicit member names).

Also fixed a pre-existing failure in `test_multiple_delegates`: each `connection_didFailWithError_` callback calls `CFRunLoopStop`, so a single `CFRunLoopRunInMode` call exits after the first delegate fires and the second connection's event is never delivered. The fix restarts the run loop in short bursts until both delegates have been called (or a 10-second timeout is reached).

